### PR TITLE
实现旧账号关联微信登录

### DIFF
--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application.Contracts/EasyAbp/WeChatManagement/MiniPrograms/Login/Dtos/GetPcBindACodeOutput.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application.Contracts/EasyAbp/WeChatManagement/MiniPrograms/Login/Dtos/GetPcBindACodeOutput.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EasyAbp.WeChatManagement.MiniPrograms.Login.Dtos
+{
+    public class GetPcBindACodeOutput : GetPcLoginACodeOutput
+    {
+        public int ExpiredTime { get; set; }
+        public bool HasBound { get; set; }
+        public string NickName { get; set; }
+        public string AvatarUrl { get; set; }
+    }
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application.Contracts/EasyAbp/WeChatManagement/MiniPrograms/Login/Dtos/LoginInput.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application.Contracts/EasyAbp/WeChatManagement/MiniPrograms/Login/Dtos/LoginInput.cs
@@ -20,6 +20,11 @@ namespace EasyAbp.WeChatManagement.MiniPrograms.Login.Dtos
         public string Code { get; set; }
 
         /// <summary>
+        /// 待绑定账号的临时Token
+        /// </summary>
+        public string Token { get; set; }
+
+        /// <summary>
         /// 查找并使用最近一次登录的租户登录（忽略当前租户环境）
         /// </summary>
         public bool LookupUseRecentlyTenant { get; set; }

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application.Contracts/EasyAbp/WeChatManagement/MiniPrograms/Login/Dtos/PcBindInput.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application.Contracts/EasyAbp/WeChatManagement/MiniPrograms/Login/Dtos/PcBindInput.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+
+namespace EasyAbp.WeChatManagement.MiniPrograms.Login.Dtos
+{
+    [Serializable]
+    public class PcBindInput
+    {
+        [Required]
+        public string Token { get; set; }
+
+        [Required]
+        public int Times { get; set; }
+    }
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application.Contracts/EasyAbp/WeChatManagement/MiniPrograms/Login/Dtos/PcBindOutput.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application.Contracts/EasyAbp/WeChatManagement/MiniPrograms/Login/Dtos/PcBindOutput.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EasyAbp.WeChatManagement.MiniPrograms.Login.Dtos
+{
+    public class PcBindOutput
+    {
+        /// <summary>
+        /// 扫码过期
+        /// </summary>
+        public bool Expired { get; set; }
+        /// <summary>
+        /// 成功扫码
+        /// </summary>
+        public bool IsSucess { get; set; }
+        /// <summary>
+        /// 成功绑定
+        /// </summary>
+        public bool HasBound { get; set; }/*
+        /// <summary>
+        /// 昵称
+        /// </summary>
+        public string NickName { get; set; }
+        /// <summary>
+        /// 头像
+        /// </summary>
+        public string AvatarUrl { get; set; }*/
+    }
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application.Contracts/EasyAbp/WeChatManagement/MiniPrograms/Login/ILoginAppService.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application.Contracts/EasyAbp/WeChatManagement/MiniPrograms/Login/ILoginAppService.cs
@@ -13,7 +13,12 @@ namespace EasyAbp.WeChatManagement.MiniPrograms.Login
 
         Task<GetPcLoginACodeOutput> GetPcLoginACodeAsync([NotNull] string miniProgramName,
             [CanBeNull] string handlePage = null);
+
+        Task<GetPcBindACodeOutput> GetPcBindACodeAsync([NotNull] string miniProgramName,
+            [CanBeNull] string handlePage = null);
         
+        Task<PcBindOutput> PcBindStatusAsync(PcBindInput input);
+
         Task AuthorizePcAsync(AuthorizePcInput input);
         
         Task<PcLoginOutput> PcLoginAsync(PcLoginInput input);

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application/EasyAbp/WeChatManagement/MiniPrograms/Login/MiniProgramPcUserBindCacheItem.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application/EasyAbp/WeChatManagement/MiniPrograms/Login/MiniProgramPcUserBindCacheItem.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EasyAbp.WeChatManagement.MiniPrograms.Login
+{
+    public class MiniProgramPcUserBindCacheItem
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application/EasyAbp/WeChatManagement/MiniPrograms/Login/PcUserBindACodeHasExpiredException.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application/EasyAbp/WeChatManagement/MiniPrograms/Login/PcUserBindACodeHasExpiredException.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp;
+
+namespace EasyAbp.WeChatManagement.MiniPrograms.Login
+{
+    public class PcUserBindACodeHasExpiredException : UserFriendlyException
+    {
+        public PcUserBindACodeHasExpiredException() : base("二维码已过期，请重新扫码", "BindCodeHasExpired")
+        {
+
+        }
+    }
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application/EasyAbp/WeChatManagement/MiniPrograms/Login/PcUserBindACodeInvalidException.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application/EasyAbp/WeChatManagement/MiniPrograms/Login/PcUserBindACodeInvalidException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp;
+
+namespace EasyAbp.WeChatManagement.MiniPrograms.Login
+{
+    public class PcUserBindACodeInvalidException : UserFriendlyException
+    {
+        public PcUserBindACodeInvalidException() : base("绑定无效", "BindInvalid")
+        {
+
+        }
+    }
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Domain.Shared/EasyAbp/WeChatManagement/MiniPrograms/Localization/en.json
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Domain.Shared/EasyAbp/WeChatManagement/MiniPrograms/Localization/en.json
@@ -17,6 +17,8 @@
     "UserInfoAvatarUrl": "UserInfoAvatarUrl",
     "Setting:PcLoginHandlePage": "Setting:PcLoginHandlePage",
     "Setting:DefaultPcLoginWeChatAppName": "Setting:DefaultPcLoginWeChatAppName",
+    "Setting:BindCodeExpiredTime": "Setting:BindCodeExpiredTime",
+    "HasBound": "HasBound",
     "WeChatAccountHasBeenBound": "WeChatAccountHasBeenBound",
     "WeChatAccountHasNotBeenBound": "WeChatAccountHasNotBeenBound"
   }

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Domain.Shared/EasyAbp/WeChatManagement/MiniPrograms/Localization/zh-Hans.json
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Domain.Shared/EasyAbp/WeChatManagement/MiniPrograms/Localization/zh-Hans.json
@@ -17,6 +17,8 @@
     "UserInfoAvatarUrl": "头像图片",
     "Setting:PcLoginHandlePage": "PC 登录处理页面",
     "Setting:DefaultPcLoginWeChatAppName": "PC 登录默认微信应用名",
+    "Setting:BindCodeExpiredTime": "绑定码过期时间（秒）",
+    "HasBound": "已绑定",
     "WeChatAccountHasBeenBound": "您的微信已被其他用户绑定",
     "WeChatAccountHasNotBeenBound": "您的微信尚未绑定"
   }

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Domain.Shared/EasyAbp/WeChatManagement/MiniPrograms/Localization/zh-Hant.json
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Domain.Shared/EasyAbp/WeChatManagement/MiniPrograms/Localization/zh-Hant.json
@@ -17,6 +17,8 @@
     "UserInfoAvatarUrl": "頭像圖片",
     "Setting:PcLoginHandlePage": "PC 登錄處理頁面",
     "Setting:DefaultPcLoginWeChatAppName": "PC 登錄默認微信應用名",
+    "Setting:BindCodeExpiredTime": "綁定碼過期時間（秒）",
+    "HasBound": "已綁定",
     "WeChatAccountHasBeenBound": "您的微信已被其他用戶綁定",
     "WeChatAccountHasNotBeenBound": "您的微信尚未綁定"
   }

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Domain/EasyAbp/WeChatManagement/MiniPrograms/Settings/MiniProgramsSettingDefinitionProvider.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Domain/EasyAbp/WeChatManagement/MiniPrograms/Settings/MiniProgramsSettingDefinitionProvider.cs
@@ -25,6 +25,14 @@ namespace EasyAbp.WeChatManagement.MiniPrograms.Settings
                 L("Setting:PcLoginHandlePage"),
                 isVisibleToClients: true
             ));
+
+            context.Add(new SettingDefinition(
+                MiniProgramsSettings.PcLogin.BindCodeExpiredTime,
+                "60",
+                L("Setting:BindCodeExpiredTime"),
+                isVisibleToClients: true
+            ));
+
         }
         
         private static LocalizableString L(string name)

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Domain/EasyAbp/WeChatManagement/MiniPrograms/Settings/MiniProgramsSettings.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Domain/EasyAbp/WeChatManagement/MiniPrograms/Settings/MiniProgramsSettings.cs
@@ -15,6 +15,11 @@
             public const string DefaultProgramName = PcLoginGroupName + ".DefaultMiniProgramName";
         
             public const string HandlePage = PcLoginGroupName + ".HandlePage";
+
+            /// <summary>
+            /// 单位（秒）
+            /// </summary>
+            public const string BindCodeExpiredTime = PcLoginGroupName + ".BindCodeExpiredTime";
         }
     }
 }

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.HttpApi/EasyAbp/WeChatManagement/MiniPrograms/Login/LoginController.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.HttpApi/EasyAbp/WeChatManagement/MiniPrograms/Login/LoginController.cs
@@ -39,6 +39,21 @@ namespace EasyAbp.WeChatManagement.MiniPrograms.Login
             return _service.GetPcLoginACodeAsync(miniProgramName, handlePage);
         }
 
+        [HttpGet]
+        [Route("pc-bind-acode")]
+        [Route("pc-bind-acode/{miniProgramName}")]
+        public Task<GetPcBindACodeOutput> GetPcBindACodeAsync(string miniProgramName, string handlePage = null)
+        {
+            return _service.GetPcBindACodeAsync(miniProgramName, handlePage);
+        }
+
+        [HttpPost]
+        [Route("pc-bind-status")]
+        public Task<PcBindOutput> PcBindStatusAsync(PcBindInput input)
+        {
+            return _service.PcBindStatusAsync(input);
+        }
+
         [HttpPost]
         [Route("authorize-pc")]
         public Task AuthorizePcAsync(AuthorizePcInput input)

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/EasyAbp.WeChatManagement.MiniPrograms.Web.csproj
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/EasyAbp.WeChatManagement.MiniPrograms.Web.csproj
@@ -33,7 +33,7 @@
     <Content Remove="Pages\**\*.js" />
     <Content Remove="wwwroot\**\*.*" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/Default.cshtml
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/Default.cshtml
@@ -1,0 +1,29 @@
+﻿@using EasyAbp.WeChatManagement.MiniPrograms.Localization
+@using Microsoft.AspNetCore.Mvc.Localization
+@model EasyAbp.WeChatManagement.MiniPrograms.Web.Pages.WeChatManagement.MiniPrograms.Components.WeChatMiniProgramPcBindWidget.WeChatMiniProgramPcBindViewModel
+@inject IHtmlLocalizer<MiniProgramsResource> L
+<script>
+    var token = "@Model.Token";
+    var expireTime = "@Model.ExpiredTime";
+</script>
+<div class="weChat-miniProgram-pcBind-area" data-miniProgram-name="@Model.MiniProgramName">
+    <div class="weChat-miniProgram-pcBind-aCode">
+        @if (!Model.ACode.IsNullOrEmpty())
+        {
+            <img id="bindCode" src="data:image/png;base64,@Convert.ToBase64String(Model.ACode)" alt="ACode" />
+
+            <p class="count"></p>
+            <button type="button" id="btn_refresh" class="btn btn-default" onclick="location.reload()">刷新</button>
+        }
+        else if (Model.HasBound)
+        {
+            <h2>@L["HasBound"]</h2>
+            <img src="@Model.AvatarUrl" class="avatar-img" alt="avatar" />
+            <h5 style="padding:10px">@Model.NickName</h5>
+        }
+        else
+        {
+            <h2>@L["ACodeGenerationFailed"]</h2>
+        }
+    </div>
+</div>

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/WeChatMiniProgramPcBindScriptBundleContributor.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/WeChatMiniProgramPcBindScriptBundleContributor.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
+
+namespace EasyAbp.WeChatManagement.MiniPrograms.Web.Pages.WeChatManagement.MiniPrograms.Components.WeChatMiniProgramPcBindWidget
+{
+    public class WeChatMiniProgramPcBindScriptBundleContributor : BundleContributor
+    {
+        public override void ConfigureBundle(BundleConfigurationContext context)
+        {
+            context.Files.AddIfNotContains(
+                "/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/default.js");
+        }
+    }
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/WeChatMiniProgramPcBindStyleBundleContributor.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/WeChatMiniProgramPcBindStyleBundleContributor.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
+
+namespace EasyAbp.WeChatManagement.MiniPrograms.Web.Pages.WeChatManagement.MiniPrograms.Components.WeChatMiniProgramPcBindWidget
+{
+    public class WeChatMiniProgramPcBindStyleBundleContributor : BundleContributor
+    {
+        public override void ConfigureBundle(BundleConfigurationContext context)
+        {
+            context.Files.AddIfNotContains(
+                "/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/default.css");
+        }
+    }
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/WeChatMiniProgramPcBindViewModel.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/WeChatMiniProgramPcBindViewModel.cs
@@ -1,0 +1,9 @@
+﻿using EasyAbp.WeChatManagement.MiniPrograms.Login.Dtos;
+
+namespace EasyAbp.WeChatManagement.MiniPrograms.Web.Pages.WeChatManagement.MiniPrograms.Components.WeChatMiniProgramPcBindWidget
+{
+    public class WeChatMiniProgramPcBindViewModel : GetPcBindACodeOutput
+    {
+        public string MiniProgramName { get; set; }
+    }
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/WeChatMiniProgramPcBindWidgetViewComponent.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/WeChatMiniProgramPcBindWidgetViewComponent.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Threading.Tasks;
+using EasyAbp.WeChatManagement.MiniPrograms.Login;
+using EasyAbp.WeChatManagement.MiniPrograms.Login.Dtos;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp.AspNetCore.Mvc;
+using Volo.Abp.AspNetCore.Mvc.UI.Widgets;
+
+namespace EasyAbp.WeChatManagement.MiniPrograms.Web.Pages.WeChatManagement.MiniPrograms.Components.WeChatMiniProgramPcBindWidget
+{
+    [ViewComponent(Name = "WeChatMiniProgramPcBind")]
+    [Widget(
+        ScriptTypes = new[] { typeof(WeChatMiniProgramPcBindScriptBundleContributor) },
+        StyleTypes = new[] { typeof(WeChatMiniProgramPcBindStyleBundleContributor) }
+    )]
+    public class WeChatMiniProgramPcBindWidgetViewComponent : AbpViewComponent
+    {
+        private readonly ILoginAppService _loginAppService;
+
+        public WeChatMiniProgramPcBindWidgetViewComponent(ILoginAppService loginAppService)
+        {
+            _loginAppService = loginAppService;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="miniProgramName"></param>
+        /// <param name="codeType">二维码类型</param>
+        /// <returns></returns>
+        public async Task<IViewComponentResult> InvokeAsync(string miniProgramName)
+        {
+            GetPcBindACodeOutput aCode;
+            try
+            {
+                aCode = await _loginAppService.GetPcBindACodeAsync(miniProgramName);
+            }
+            catch
+            {
+                aCode = new GetPcBindACodeOutput
+                {
+                    ACode = null,
+                    Token = null
+                };
+            }
+
+            var viewModel = new WeChatMiniProgramPcBindViewModel
+            {
+                MiniProgramName = miniProgramName,
+                Token = aCode.Token,
+                ACode = aCode.ACode,
+                ExpiredTime = aCode.ExpiredTime,
+                HasBound = aCode.HasBound,
+                NickName = aCode.NickName,
+                AvatarUrl = aCode.AvatarUrl,
+            };
+
+            return View(
+                "~/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/Default.cshtml",
+                viewModel);
+        }
+    }
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/default.css
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/default.css
@@ -1,0 +1,33 @@
+﻿.weChat-miniProgram-pcBind-aCode {
+    max-width: 350px;
+    margin: 30px auto 0;
+}
+
+.weChat-miniProgram-pcBind-aCode img {
+    width: 100%;
+}
+
+.weChat-miniProgram-pcBind-aCode .count{
+    padding:15px;
+}
+
+.expire-layer {
+    max-width: 350px;
+    position: relative;
+    color: #000000;
+    background-color: #f5f5f7;
+    opacity: 0.1;
+    display: grid;
+    filter: blur(4px);
+}
+.expire-txt {
+    position: relative;
+    width: 100%;
+    font-size: xxx-large;
+    transform: translateY(-100px);
+}
+
+.avatar-img {
+    border-radius: 50%;
+    max-width: 120px;
+}

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/default.js
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Web/Pages/WeChatManagement/MiniPrograms/Components/WeChatMiniProgramPcBindWidget/default.js
@@ -1,0 +1,74 @@
+﻿/*
+if (token != null && token != '') {
+    var intervalID = window.setInterval(function () {
+        if (expireTime == 0) {
+            document.querySelector("#bindCode").setAttribute("class", "expire-layer")
+            document.querySelector(".count").innerHTML = "二维码已过期";
+            setTimeout(function () {
+                clearInterval(intervalID);
+            }, 1000)
+            return;
+        }
+        document.querySelector(".count").innerHTML = `${expireTime} 秒后过期`;
+        expireTime--;
+
+    }, 1000);
+}
+*/
+//(function ($) {
+
+//    $(document).ready(function () {
+
+        abp.widgets.WeChatMiniProgramPcBind = function ($widget) {
+
+            var widgetManager = $widget.data('abp-widget-manager');
+            var $pcBindArea = $widget.find('.weChat-miniProgram-pcBind-area');
+
+            function getFilters() {
+                return {};
+            }
+
+            function init() {
+                if (token == null || token === '') return;
+
+                var intervalClock = window.setInterval(function () {
+                    if (expireTime == 0) {
+                        document.querySelector("#bindCode").setAttribute("class", "expire-layer")
+                        document.querySelector(".count").innerHTML = "二维码已失效";
+                        setTimeout(function () {
+                            clearInterval(intervalClock);
+                        }, 1000)
+                        return;
+                    }
+                    document.querySelector(".count").innerHTML = `${expireTime} 秒后过期`;
+                    expireTime--;
+
+                }, 1000);
+
+                var intervalID = window.setInterval(function () {
+                    easyAbp.weChatManagement.miniPrograms.login.login.pcBindStatus({ token: token, times: expireTime }, {
+                        success: function (data) {
+                            if (data.expired) {
+                                document.querySelector(".count").innerHTML = "二维码已失效";
+                                clearInterval(intervalID);
+                            } else if (data.hasBound) {
+                                document.location.reload();
+                            } else if (data.isSucess) {
+                                expireTime -= 3;
+                                document.querySelector(".count").innerHTML = `$已扫码`;
+                                clearInterval(intervalClock);
+                            }
+                        }
+                    });
+                }, 3000);
+            }
+            return {
+                init: init,
+                getFilters: getFilters
+            };
+        };
+
+        var widgetManager = new abp.WidgetManager({ filterForm: 'WeChatMiniProgramPcBind' });
+        widgetManager.init();
+//    });
+//})(jQuery);

--- a/samples/WeChatManagementSample/aspnet-core/src/WeChatManagementSample.Web/Pages/Index.cshtml
+++ b/samples/WeChatManagementSample/aspnet-core/src/WeChatManagementSample.Web/Pages/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using EasyAbp.WeChatManagement.MiniPrograms.Web.Pages.WeChatManagement.MiniPrograms.Components.WeChatMiniProgramPcBindWidget
 @using Microsoft.AspNetCore.Mvc.Localization
 @using WeChatManagementSample.Localization
 @using Volo.Abp.Users
@@ -10,22 +11,30 @@
         <abp-style src="/Pages/Index.css" />
     </abp-style-bundle>
 }
-@section scripts {
+    @section scripts {
     <abp-script-bundle>
         <abp-script src="/Pages/Index.js" />
     </abp-script-bundle>
 }
-<div class="jumbotron text-center">
-    <h1>@L["Welcome"]</h1>
-    <div class="row">
-        <div class="col-md-6 mx-auto">
-            <p>@L["LongWelcomeMessage"]</p>
-            <hr class="my-4"/>
+    <div class="jumbotron text-center">
+        <h1>@L["Welcome"]</h1>
+        <div class="row">
+            <div class="col-md-6 mx-auto">
+                <p>@L["LongWelcomeMessage"]</p>
+
+            </div>
         </div>
-    </div>
-    <a href="https://abp.io?ref=tmpl" target="_blank" class="btn btn-primary px-4">abp.io</a>
-    @if (!CurrentUser.IsAuthenticated)
+        <a href="https://abp.io?ref=tmpl" target="_blank" class="btn btn-primary px-4">abp.io</a>
+        <hr class="my-4" />
+        @if (!CurrentUser.IsAuthenticated)
     {
         <a abp-button="Primary" href="~/Account/Login" class="px-4"><i class="fa fa-sign-in"></i> @L["Login"]</a>
+    }
+    else
+    {
+        <div class="col-md-auto text-center icon">
+            绑定现有账号
+        </div>
+        @await Component.InvokeAsync(typeof(WeChatMiniProgramPcBindWidgetViewComponent), Model.MiniProgramName)
     }
 </div>

--- a/samples/WeChatManagementSample/aspnet-core/src/WeChatManagementSample.Web/Pages/Index.cshtml.cs
+++ b/samples/WeChatManagementSample/aspnet-core/src/WeChatManagementSample.Web/Pages/Index.cshtml.cs
@@ -1,10 +1,17 @@
-﻿namespace WeChatManagementSample.Web.Pages
+﻿using EasyAbp.WeChatManagement.MiniPrograms.Settings;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace WeChatManagementSample.Web.Pages
 {
     public class IndexModel : WeChatManagementSamplePageModel
     {
-        public void OnGet()
+        [BindProperty(SupportsGet = true)]
+        public string MiniProgramName { get; set; }
+
+        public async Task OnGetAsync()
         {
-            
+            MiniProgramName ??= await SettingProvider.GetOrNullAsync(MiniProgramsSettings.PcLogin.DefaultProgramName);
         }
     }
 }


### PR DESCRIPTION
绑定步骤：
1. PC端调用 `WeChatMiniProgramPcLoginWidget` 组件生成绑定二维码，确保PC端已登录。
2. 小程序扫码登录接口 `/api/wechat-management/mini-programs/login/login` 在原接口的基础上增加 `Token` 参数，值填充二维码中的 `scene` 值

绑定码参数：
`EasyAbp.WeChatManagement.MiniPrograms.BindCodeExpiredTime` 设置绑定码缓存过期时间，单位：秒