### PR TITLE
修复检测到手机号后 没有添加用户logininfo导致老用户无法登陆的问题

### DIFF
--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application/EasyAbp/WeChatManagement/MiniPrograms/Login/LoginAppService.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application/EasyAbp/WeChatManagement/MiniPrograms/Login/LoginAppService.cs
@@ -175,6 +175,8 @@ namespace EasyAbp.WeChatManagement.MiniPrograms.Login
                         phoneNumber = phoneNumberResponse.PhoneInfo.PhoneNumber;
                         // If successfully got the phone number, try to find user by it
                         identityUser = await _uniquePhoneNumberIdentityUserRepository.FindByConfirmedPhoneNumberAsync(phoneNumber);
+
+                        (await _identityUserManager.AddLoginAsync(identityUser, new UserLoginInfo(loginResult.LoginProvider, loginResult.ProviderKey, WeChatManagementCommonConsts.WeChatUserLoginInfoDisplayName))).CheckErrors();
                     }
                 }
 

--- a/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application/EasyAbp/WeChatManagement/MiniPrograms/Login/LoginAppService.cs
+++ b/modules/MiniPrograms/src/EasyAbp.WeChatManagement.MiniPrograms.Application/EasyAbp/WeChatManagement/MiniPrograms/Login/LoginAppService.cs
@@ -176,7 +176,10 @@ namespace EasyAbp.WeChatManagement.MiniPrograms.Login
                         // If successfully got the phone number, try to find user by it
                         identityUser = await _uniquePhoneNumberIdentityUserRepository.FindByConfirmedPhoneNumberAsync(phoneNumber);
 
-                        (await _identityUserManager.AddLoginAsync(identityUser, new UserLoginInfo(loginResult.LoginProvider, loginResult.ProviderKey, WeChatManagementCommonConsts.WeChatUserLoginInfoDisplayName))).CheckErrors();
+                        if (identityUser != null)
+                        {
+                            (await _identityUserManager.AddLoginAsync(identityUser, new UserLoginInfo(loginResult.LoginProvider, loginResult.ProviderKey, WeChatManagementCommonConsts.WeChatUserLoginInfoDisplayName))).CheckErrors();
+                        }
                     }
                 }
 


### PR DESCRIPTION
After successfully retrieving the user's phone number and finding the corresponding user, this commit adds the WeChat login info to the user account. This ensures that users can log in with their WeChat credentials after phone number verification.